### PR TITLE
Fix bili watch npm script (fixes npm run dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,4 @@ npm i react react-dom parcel-bundler -D
 
 - https://areknawo.com/full-blown-monorepo-setup-walkthrough/
 - [🔴 Setup a monorepo with Lerna 🐉](https://www.youtube.com/watch?v=pU87ufl2lDc) - [chantastic](https://www.youtube.com/channel/UCXpmUxvG37qpckRHdkstf5w)
+- [Running bili/rollup --watch with lerna](https://stackoverflow.com/a/55655749/2058360)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build:packages && npm run build:storybook",
     "create": "hygen component new",
     "dev:storybook": "start-storybook -p 6006 --ci --quiet",
-    "dev:watch": "lerna run watch",
+    "dev:watch": "lerna exec --parallel npm run watch",
     "dev": "npm-run-all --parallel dev:*"
   },
   "keywords": [],

--- a/packages/button/src/Button.js
+++ b/packages/button/src/Button.js
@@ -3,9 +3,11 @@
 import React from "react";
 import styles from "./Button.module.scss";
 
-export function Button({ ...props }) {
-  return <div className={styles.root} {...props} />;
+export function Button({ onClick, children, ...props }) {
+  return (
+    <div className={styles.root} {...props}>
+      <h1>{children}</h1>
+      <button onClick={onClick}>example</button>
+    </div>
+  );
 }
-
-
-

--- a/packages/button/src/Button.module.scss
+++ b/packages/button/src/Button.module.scss
@@ -1,3 +1,3 @@
 .root {
-  outline: 1px solid red;
+  outline: 1px solid orange;
 }

--- a/packages/button/src/Button.stories.js
+++ b/packages/button/src/Button.stories.js
@@ -7,10 +7,9 @@ export default {
   title: "Button"
 };
 
-export const Default = () => <Button>wut up</Button>;
-export const Close = () => (
-  <Button type="button" onClick={action("onClick")}>
-    <CloseIcon style={{ fill: "orange" }} />
-    hello
+export const Default = () => (
+  <Button onClick={action("onClick")}>
+    <CloseIcon />
+    wut up
   </Button>
 );


### PR DESCRIPTION
- Doing `npm run dev` to execute `lerna run watch` wouldn't actually run the `bili --watch` command. Changes to components like `Button.js` wouldn't trigger rebuilds. 
This PR fixes it. 